### PR TITLE
Criação inicial da controller e DTOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/controller/JwtValidatorController.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/controller/JwtValidatorController.java
@@ -1,0 +1,22 @@
+package com.jonas.rodrigues.jwt_validator_api.controller;
+
+import com.jonas.rodrigues.jwt_validator_api.dto.JwtRequestDTO;
+import com.jonas.rodrigues.jwt_validator_api.dto.JwtResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/jwt-validator")
+@Slf4j
+public class JwtValidatorController {
+
+    @PostMapping
+    public ResponseEntity<JwtResponseDTO> validateJwt(@RequestBody JwtRequestDTO jwtRequest) {
+        log.info("Received JWT for validation: {}", jwtRequest.token());
+
+        JwtResponseDTO response = new JwtResponseDTO(true);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/dto/JwtRequestDTO.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/dto/JwtRequestDTO.java
@@ -1,0 +1,8 @@
+package com.jonas.rodrigues.jwt_validator_api.dto;
+import jakarta.validation.constraints.NotBlank;
+
+
+public record JwtRequestDTO(
+    @NotBlank(message = "Token JWT is required")
+    String token
+) {}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/dto/JwtResponseDTO.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/dto/JwtResponseDTO.java
@@ -1,0 +1,4 @@
+package com.jonas.rodrigues.jwt_validator_api.dto;
+
+public record JwtResponseDTO(boolean valid) {
+}


### PR DESCRIPTION
✅Realizado
- Criação da controller base para expor o endpoint de validação do JWT.
- Implementação do JwtRequestDTO contendo o token recebido na requisição.
- Implementação do JwtResponseDTO contendo o resultado da validação (true ou false).
- Adição da dependencia do jakarta.validation no pom.xml, para utilizar anotações de validação, como o NotBlank, usada no #JwtRequestDTO

🧾Motivo:
Essa etapa inicial prepara a estrutura básica da API REST, definindo claramente a entrada e saída da aplicação, de acordo com os requisitos do desafio técnico.

⏭️Próximos passos:
- Implementar o parser de JWT e a extração das claims.
- Criar a classe JwtClaims.
- Desenvolver as validações individuais conforme as regras do desafio.