### PR TITLE
Implementação do serviço de validação de JWT com regras de negócio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
 			<artifactId>jakarta.validation-api</artifactId>
 			<version>3.1.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/controller/JwtValidatorController.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/controller/JwtValidatorController.java
@@ -2,7 +2,9 @@ package com.jonas.rodrigues.jwt_validator_api.controller;
 
 import com.jonas.rodrigues.jwt_validator_api.dto.JwtRequestDTO;
 import com.jonas.rodrigues.jwt_validator_api.dto.JwtResponseDTO;
+import com.jonas.rodrigues.jwt_validator_api.service.JwtValidationService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,12 +13,12 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class JwtValidatorController {
 
+    @Autowired
+    private JwtValidationService jwtValidationService;
+
     @PostMapping
     public ResponseEntity<JwtResponseDTO> validateJwt(@RequestBody JwtRequestDTO jwtRequest) {
         log.info("Received JWT for validation: {}", jwtRequest.token());
-
-        JwtResponseDTO response = new JwtResponseDTO(true);
-
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(jwtValidationService.validate(jwtRequest));
     }
 }

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/entity/JwtClaims.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/entity/JwtClaims.java
@@ -1,0 +1,7 @@
+package com.jonas.rodrigues.jwt_validator_api.entity;
+
+public record JwtClaims(
+    String role,
+    String seed,
+    String name
+) {}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/JwtValidationService.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/JwtValidationService.java
@@ -1,0 +1,68 @@
+package com.jonas.rodrigues.jwt_validator_api.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.jonas.rodrigues.jwt_validator_api.dto.JwtRequestDTO;
+import com.jonas.rodrigues.jwt_validator_api.dto.JwtResponseDTO;
+import com.jonas.rodrigues.jwt_validator_api.entity.JwtClaims;
+import com.jonas.rodrigues.jwt_validator_api.service.validator.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class JwtValidationService {
+
+    public JwtResponseDTO validate(JwtRequestDTO request) {
+        try {
+            log.info("Validating JWT: {}", request.token());
+            DecodedJWT decoded = decodeToken(request.token());
+            Map<String, Object> claimsMap = decoded.getClaims().entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey,
+                            e -> e.getValue().as(Object.class)));
+
+            JwtClaims claims = new JwtClaims(
+                decoded.getClaim("Role").asString(),
+                decoded.getClaim("Seed").asString(),
+                decoded.getClaim("Name").asString()
+            );
+
+            log.info("Decoded JWT claims: {}", claims);
+
+            List<JwtRuleValidator> validators = List.of(
+                new ClaimsCountValidator(claimsMap),
+                new NameValidator(),
+                new RoleValidator(),
+                new SeedValidator()
+            );
+
+            List<String> reasons = new ArrayList<>();
+            boolean allValid = validators.stream()
+                .allMatch(validator -> {
+                    boolean isValid = validator.isValid(claims);
+                    if (!isValid) reasons.add(validator.getReason());
+                    return isValid;
+                });
+
+            if (!allValid) {
+                log.warn("JWT validation failed: {}", reasons);
+            } else {
+                log.info("JWT validation succeeded");
+            }
+
+            return new JwtResponseDTO(allValid);
+        } catch (Exception e) {
+            log.error("Error validating JWT: {}", e.getMessage());
+            return new JwtResponseDTO(false);
+        }
+    }
+
+    private DecodedJWT decodeToken(String token) {
+        return JWT.decode(token);
+    }
+}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/ClaimsCountValidator.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/ClaimsCountValidator.java
@@ -1,0 +1,24 @@
+package com.jonas.rodrigues.jwt_validator_api.service.validator;
+
+import com.jonas.rodrigues.jwt_validator_api.entity.JwtClaims;
+
+import java.util.Map;
+
+public class ClaimsCountValidator implements JwtRuleValidator {
+    private final Map<String, Object> claimsMap;
+    private static final String REASON = "JWT must contain exactly 3 claims.";
+
+    public ClaimsCountValidator(Map<String, Object> claimsMap) {
+        this.claimsMap = claimsMap;
+    }
+
+    @Override
+    public boolean isValid(JwtClaims claims) {
+        return claimsMap.size() == 3;
+    }
+
+    @Override
+    public String getReason() {
+        return REASON;
+    }
+}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/JwtRuleValidator.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/JwtRuleValidator.java
@@ -1,0 +1,8 @@
+package com.jonas.rodrigues.jwt_validator_api.service.validator;
+
+import com.jonas.rodrigues.jwt_validator_api.entity.JwtClaims;
+
+public interface JwtRuleValidator {
+    boolean isValid(JwtClaims claims);
+    String getReason();
+}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/NameValidator.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/NameValidator.java
@@ -1,0 +1,33 @@
+package com.jonas.rodrigues.jwt_validator_api.service.validator;
+
+import com.jonas.rodrigues.jwt_validator_api.entity.JwtClaims;
+
+public class NameValidator implements JwtRuleValidator {
+
+    private static final String REASON = "Name must be <= 256 characters and contain no digits";
+
+    @Override
+    public boolean isValid(JwtClaims claims) {
+        String name = claims.name();
+        return !nameIsNullOrEmpty(name) &&
+               !nameExceedsMaxLength(name) &&
+               !nameContainsDigits(name);
+    }
+
+    private boolean nameIsNullOrEmpty(String name) {
+        return name == null || name.trim().isEmpty();
+    }
+
+    private boolean nameExceedsMaxLength(String name) {
+        return name.length() > 256;
+    }
+
+    private boolean nameContainsDigits(String name) {
+        return name.matches(".*\\d.*");
+    }
+
+    @Override
+    public String getReason() {
+        return REASON;
+    }
+}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/RoleValidator.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/RoleValidator.java
@@ -1,0 +1,22 @@
+package com.jonas.rodrigues.jwt_validator_api.service.validator;
+
+import com.jonas.rodrigues.jwt_validator_api.entity.JwtClaims;
+
+import java.util.Set;
+
+public class RoleValidator implements JwtRuleValidator {
+
+    private static final Set<String> VALID_ROLES = Set.of("Admin", "Member", "External");
+    private static final String REASON = "Role must be one of: Admin, Member, External.";
+
+    @Override
+    public boolean isValid(JwtClaims claims) {
+        return VALID_ROLES.contains(claims.role());
+    }
+
+    @Override
+    public String getReason() {
+        return REASON;
+    }
+
+}

--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/SeedValidator.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/SeedValidator.java
@@ -1,0 +1,29 @@
+package com.jonas.rodrigues.jwt_validator_api.service.validator;
+
+import com.jonas.rodrigues.jwt_validator_api.entity.JwtClaims;
+
+public class SeedValidator implements JwtRuleValidator {
+
+    private static final String REASON = "Seed must be a valid prime number";
+
+    @Override
+    public boolean isValid(JwtClaims claims) {
+        try {
+            int seed = Integer.parseInt(claims.seed());
+            return isPrime(seed);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private boolean isPrime(int number) {
+        if (number < 2) return false;
+        return java.util.stream.IntStream.rangeClosed(2, (int) Math.sqrt(number))
+                .noneMatch(i -> number % i == 0);
+    }
+
+    @Override
+    public String getReason() {
+        return REASON;
+    }
+}


### PR DESCRIPTION
✅ O que foi feito:

- Criação do JwtValidationService, responsável por coordenar a extração e validação das claims do token JWT.
- Implementação do parser para extrair as claims Name, Role e Seed.
- Criação da interface JwtRuleValidator para aplicar o padrão Strategy nas validações.
- Implementação dos validadores:
- NameValidator: verifica se o nome não contém números e tem no máximo 256 caracteres.
- RoleValidator: garante que o role seja um dos valores válidos (Admin, Member, External).
- SeedValidator: valida se a claim Seed representa um número primo.
- ClaimsCountValidator: valida se o token contém exatamente 3 claims.

🧱 Motivo:
Essa etapa estabelece as regras de negócio centrais da aplicação, promovendo baixo acoplamento e alta coesão com base em princípios SOLID. As validações foram desacopladas em componentes reutilizáveis, facilitando a manutenção e os testes.

🧪 Próximos passos:
Criar testes unitários para cada validador individualmente.