### PR TITLE
fix(RoleValidator): valid if claims is null

### DIFF
--- a/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/RoleValidator.java
+++ b/src/main/java/com/jonas/rodrigues/jwt_validator_api/service/validator/RoleValidator.java
@@ -11,6 +11,9 @@ public class RoleValidator implements JwtRuleValidator {
 
     @Override
     public boolean isValid(JwtClaims claims) {
+        if (claims == null || claims.role() == null) {
+            return false;
+        }
         return VALID_ROLES.contains(claims.role());
     }
 


### PR DESCRIPTION
O método isValid agora retorna falso se JwtClaims ou sua função forem nulos, evitando possíveis NullPointerExceptions durante a validação com testes unitários.